### PR TITLE
Add 'mkd' to package bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A custom render for marked to output to the Terminal",
   "main": "index.js",
   "bin": {
-    "md": "./bin/md.js"
+	"md": "./bin/md.js",
+	"mkd":"./bin/md.js"
   },
   "scripts": {
     "test": "FORCE_HYPERLINK=0 mocha tests/*.js --reporter spec",


### PR DESCRIPTION
A workaround for the naming conflict with bash command 'md'.
